### PR TITLE
Docs: add required parameter to registration cert command

### DIFF
--- a/docs/tutorials/register-spo.mdx
+++ b/docs/tutorials/register-spo.mdx
@@ -127,6 +127,7 @@ export CARDANO_NODE_SOCKET_PATH=~/node.socket
 cardano-cli stake-address registration-certificate \
 --conway-era \
 --stake-verification-key-file stake.vkey \
+--key-reg-deposit-amt 2000000 \
 --out-file registration.cert
 ```
 


### PR DESCRIPTION
Add required parameter to stake-address registration-certificate command in docs.

Without this parameter, the following error is returned when running the `cardano-cli stake-address registration-certificate` with `--conway-era`:

`Command failed: stake-address registration-certificate  Error: StakeAddressRegistrationDepositRequired`

This is now a required parameter according to [this code](https://github.com/input-output-hk/cardano-cli/blob/f2b12c514ccc6e95b6b688e17c1eea8abafef228/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs#L116)