### PR TITLE
Tidy up register-spo.mdx

### DIFF
--- a/docs/tutorials/register-spo.mdx
+++ b/docs/tutorials/register-spo.mdx
@@ -43,12 +43,7 @@ and the port of your block producer node. This step ensures that your relay node
 {
    "localRoots":[
       {
-         "accessPoints":[
-            {
-               "address":"z.z.z.z",
-               "port":3000
-            }
-         ],
+         "accessPoints":[],
          "advertise":false,
          "valency":2
       }
@@ -198,7 +193,7 @@ cardano-cli stake-pool registration-certificate \
 --vrf-verification-key-file vrf.vkey \
 --pool-pledge 9000000000 \
 --pool-cost 340000000 \
---pool-margin .05 \
+--pool-margin 0.05 \
 --pool-reward-account-verification-key-file stake.vkey \
 --pool-owner-stake-verification-key-file stake.vkey \
 --testnet-magic 4 \


### PR DESCRIPTION
- Simplifying the relay node config.  It will not initiate a connection to the block producer node.  This allow the block producing node to have no open port exposed, even on localhost.
- Only the block producer node will initiate a connection to its relay node.
- In the cardano-cli stake-pool command, I had to use `--pool-margin 0.05` instead of `--pool-margin .05`