### PR TITLE
Fix governance vote create-vote example

### DIFF
--- a/docs/tutorials/vote-actions.mdx
+++ b/docs/tutorials/vote-actions.mdx
@@ -17,7 +17,7 @@ Create your vote file, note that `--tx-in` refers to the action ID:
 cardano-cli governance vote create-vote \
     --yes \
     --spo \
-    --tx-in 64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54#0 \
+    --tx-in "64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54#0" \
     --cold-verification-key-file cold.vkey \
     --conway-era \
     --out-file 64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54.vote


### PR DESCRIPTION
There is missing quotes in this command.  The dash symbol is otherwise interpreted as a comment by the shell.