### PR TITLE
Create file-naming-convention.mdx

### DIFF
--- a/docs/tutorials/file-naming-convention.mdx
+++ b/docs/tutorials/file-naming-convention.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 slug: /tutorials/file-naming-convention
 ---
 
-To align the tutorials, examples and also 3rd-party tooling, you can find a suggested file naming convention/schema related to Conway/Voltair Era in this document.
+To align the tutorials, examples and also 3rd-party tooling, you can find a suggested file naming convention/schema related to Conway/Voltaire Era in this document.
 
 The schemas can be extended with a `*.` prefix if needed, here is an example:
 - Suggested file name: `drep.skey`
@@ -118,14 +118,14 @@ Example content:
 }
 ```
 
-### Delegation Certificate
-`drep-deleg.cert / *.drep-deleg.cert` for the delegation certificate json
+### Vote Delegation Certificate
+`vote-deleg.cert / *.vote-deleg.cert` for the vote delegation certificate json
 
 Example content:
 ```json
 { 
-	"type": "CertificateShelley",
-	"description": "DRep Delegation Certificate",
+	"type": "CertificateConway",
+	"description": "Vote Delegation Certificate",
 	"cborHex": "83098200581cc827e7d1fb57cf12662203612fe1f0bb3578574b16f90f4a78cd355c8200581c44924d8233e23a4eda97ba2ce0a336d6152171e70960396b4903eb8a"
 }
 ```

--- a/docs/tutorials/file-naming-convention.mdx
+++ b/docs/tutorials/file-naming-convention.mdx
@@ -1,0 +1,149 @@
+---
+sidebar_label: Voting 
+title: File naming convention/schema
+sidebar_position: 7
+slug: /tutorials/file-naming-convention
+---
+
+To align the tutorials, examples and also 3rd-party tooling, you can find a suggested file naming convention/schema related to Conway/Voltair Era in this document.
+
+The schemas can be extended with a `*.` prefix if needed, here is an example:
+- Suggested file name: `drep.skey`
+- Extended with a prefix: `myname.drep.skey`
+
+As this is all work in progress, please revisit this page regulary to see if any new or changed schemas were selected.
+
+## Constitution Files
+
+Below is a list of currently used files related to the Constitution Text-Content/Action/Vote.
+
+### Text / Content
+`constitution.txt / *.constitution.txt` constitution in cleartext utf-8
+
+### Action
+`constitution.action / *.constitution.action` for action file content in json
+
+Example content:
+```json
+{
+    "type": "Governance proposal",
+    "description": "",
+    "cborHex": "841a000f4240581c1b7a61b...36a56ff490a4af6"
+}
+```
+
+### Vote
+`constitution.vote / *.constitution.vote` for the vote ballot in json
+
+Example content:
+```json
+{
+    "type": "Governance vote",
+    "description": "",
+    "cborHex": "8482582064e7cad9b3ece...1e235709ffa691001f6"
+}
+```
+
+
+## Delegate representatives (DReps) Files
+
+Below is a list of currently used files related to a Delegate Representative usage.
+
+### Signing Key
+Generated as a normal ed25519 key or derived from path `1852'/1815'/acc'/3/idx'` 
+`drep.skey / *.drep.skey` for the drep secret-key json (content like below)
+
+Example content:
+```json
+{
+    "type": "DRepSigningKey_ed25519",
+    "description": "Delegate Representative Signing Key",
+    "cborHex": "00000"
+}
+{
+    "type": "DRepExtendedSigningKey_ed25519_bip32",
+    "description": "Delegate Representative Signing Key",
+    "cborHex": "5840d84f8646463b03accf....da82c5dba3b1e4aa0df20b7"
+}
+```
+The keys derived from hardware wallets will have the keyword 'Hardware' in the description field like:
+`Hardware Delegate Representative Signing Key`
+
+### Verification Key
+`drep.vkey / *.drep.vkey` for the drep verification-key json (content like below)
+
+Example content:
+```json
+{
+    "type": "DRepVerificationKey_ed25519",
+    "description": "Delegate Representative Verification Key",
+    "cborHex": "00000"
+}
+{
+    "type": "DRepExtendedVerificationKey_ed25519_bip32",
+    "description": "Delegate Representative Verification Key",
+    "cborHex": "5820fd6b3cda64cf11f9b91ea3c88dffed906bc872f1e24566d68637c718788638d9"
+}
+```
+The keys derived from hardware wallets will have the keyword 'Hardware' in the description field like:
+`Hardware Delegate Representative Verification Key`
+
+### Identification File (ID)
+`drep.id / *.drep.id` for the drep id in bech format `drep_id1...`
+
+Example content:
+`drep_id12dggdndq3hhjzszukw5k5sulsesjux780s39h087s0p9vk6ylra`
+
+### Registration Certificate
+`drep-reg.cert / *.drep-reg.cert` for the registration certificate json
+
+Example content:
+```json
+{
+    "type": "CertificateConway",
+    "description": "DRep Registration Certificate",
+    "cborHex": "00000000"
+}
+```
+
+### Retirement Certificate
+`drep-ret.cert / *.drep-ret.cert` for the de-registration/retirement certificate json
+
+Example content:
+```json
+{
+    "type": "CertificateConway",
+    "description": "DRep Retirement Certificate",
+    "cborHex": "00000000"
+}
+```
+
+### Delegation Certificate
+`drep-deleg.cert / *.drep-deleg.cert` for the delegation certificate json
+
+Example content:
+```json
+{ 
+	"type": "CertificateShelley",
+	"description": "DRep Delegation Certificate",
+	"cborHex": "83098200581cc827e7d1fb57cf12662203612fe1f0bb3578574b16f90f4a78cd355c8200581c44924d8233e23a4eda97ba2ce0a336d6152171e70960396b4903eb8a"
+}
+```
+
+## Constitution Commitee Files
+
+Below is a list of currently used files retated to the Constitution Commitee Member usage.
+
+### Signing Key (Cold)
+`cc-cold.skey / *.cc-cold.skey` for the cold constitutional commitee member secret-key json
+
+### Signing Key (Hot)
+`cc-hot.skey / *.cc-hot.skey` for the hot constitutional commitee member secret-key json
+
+### Verification Key (Cold)
+`cc-cold.vkey / *.cc-cold.vkey` for the cold constitutional commitee member verification-key json
+
+### Verification Key (Hot)
+`cc-hot.vkey / *.cc-hot.vkey` for the hot constitutional commitee member verification-key json
+
+


### PR DESCRIPTION
Adding suggested file naming convention/schemas for the currently used files related to the conway/voltair era. Tutorials, Examples and 3rd party tools should follow the suggested naming convention.

The drep-id (drep.id) default to the bech version like we do with the stakepools right? Or should it be the hex-version and an additional drep.id-bech prefix for the bech version?

Any feedback is welcome. 