### PR TITLE
update tutorials for 8.3 [Do not merge until 8.3.0-pre is out]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "spellright.language": [
+        "en"
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex",
+        "plaintext"
+    ]
+}

--- a/docs/tutorials/create-action.mdx
+++ b/docs/tutorials/create-action.mdx
@@ -1,52 +1,91 @@
 ---
-sidebar_label: Create actions
-title: Creating governance actions
-sidebar_position: 5
+sidebar_label: Create governance actions
+title: Create governance actions
+sidebar_position: 8
 slug: /tutorials/create-action
 ---
 
-Currently, during **Phase 1**, only stake pools have the capability to **create** and **vote** on governance actions. Upcoming releases will introduce the ability for any ada holder to submit governance actions. This implies that, at present, the most effective approach to creating governance actions on SanchoNet is to become a [stake pool operator](../roles/spo.mdx).
+* Cardano node and Cardano CLI v.8.3.0-pre bring the ability for **any stake key** to create goveranance actions.
 
-Once you have your pool up and running, the process of creating an action is quite straightforward:
+### Pre-requisites
+
+* Payment key pair
+* Address with funds
+* Stake OR Stake pool key pair
+* A SanchoNet node
+
+### Preparing a new constitution
 
 1. Write a constitution update and save it to a text file:
 
 ```
-echo "We are Cardano and we are going to change the world!" > constitution.txt
+echo 'We are Cardano and we are going to change the world!' > constitution.txt
 ```
 
-2. You can check the hash of the constitution.txt file with:
+2. Upload the `constitution.txt` file to a URL so that everyone can read it, for example, https://shorturl.at/asIJ6.
+
+3. Check the hash of the `constitution.txt` file using (b2sum)[https://man7.org/linux/man-pages/man1/b2sum.1.html]. It is recommended that you download the file from the URL, just in case anything changes during the upload process.
+
+````
+wget https://shorturl.at/asIJ6 -O constitution.txt
+````
 
 ```
 b2sum -l 256 constitution.txt
 ```
 
-You should see:
+This returns the hash and the file name:
 
 ```
-df452c58fdbc203d78188f94d067d63df87891d9dba43f32b953b8ea5a959a69  constitution.txt
+3d2a9d15382c14f5ca260a2f5bfb645fe148bfe10c1d0e1d305b7b1393e2bd97  constitution.txt
 ```
 
-* The Cardano CLI may eventually offer a feature for hashing action files.
+4. Include a justification for the governance action, for example, a document with the necessary reasoning and analysis for the proposed changes: https://shorturl.at/xMS15.
+This document will not remain on-chain but will be captured by db-sync so that voting tools, explorers, wallets, and other tools can display it.
 
-3. Create the action file:
+````
+wget https://shorturl.at/xMS15 -O justification.txt
+````
+````
+b2sum -l 256 justification.txt
+````
+This returns:
+````
+13b0234dab754774e4530a0918d8272491541a8d2f6cf8ab0a10abdaa81f2440  justification.txt
+````
+
+### Creating the governance action file
+
+1. Create the action file:
 
 ```
-cardano-cli governance action create-action create-constitution \
-  --conway-era \
+cardano-cli conway governance action create-constitution \
+  --testnet \
   --governance-action-deposit 1000000 \
-  --cold-verification-key-file cold.vkey \
-  --constitution-file constitution.txt \
+  --stake-verification-key-file stake.vkey \
+  --proposal-url "https://shorturl.at/xMS15" \
+  --anchor-data-hash "13b0234dab754774e4530a0918d8272491541a8d2f6cf8ab0a10abdaa81f2440" \
+  --constitution-url "https://shorturl.at/asIJ6" \
+  --constitution "$(cat constitution.txt)" \
   --out-file constitution.action
 ```
 
-4. If everything went well, you should be able to view the content of the `constitution.action` file:
+2. If everything goes well, you should be able to view the content of the `constitution.action` file:
 
 ```
 cat constitution.action
 ```
+````
+{
+    "type": "Governance proposal",
+    "description": "",
+    "cborHex": "841a000f4240581de0bdc1c6e7b196abefcd5864c71843f481272a6590e3de7749b7931fed8305f68282781968747470733a2f2f73686f727475726c2e61742f6173494a3658203d2a9d15382c14f5ca260a2f5bfb645fe148bfe10c1d0e1d305b7b1393e2bd97f682781968747470733a2f2f73686f727475726c2e61742f784d53313558206f890de0c6e418e6526e2b1aa821850cb87aee94a6d77dc2a2e440116abc8e09"
+}
+````
 
-5. You can now build a transaction with the proposal:
+### Submitting the governance action in a transaction
+
+1. You can now build a transaction with the proposal:
 
 ```
   cardano-cli transaction build --testnet-magic 4 --conway-era \
@@ -57,18 +96,18 @@ cat constitution.action
   --out-file tx.raw
 ```
 
-6. Sign the transaction with your `cold.skey` and a `payment.skey`:
+2. Sign the transaction with your `cold.skey` and a `payment.skey`:
 
 ```
 cardano-cli transaction sign \
   --tx-body-file tx.raw \
-  --signing-key-file cold.skey \
+  --signing-key-file stake.skey \
   --signing-key-file payment.skey \
   --testnet-magic 4 \
   --out-file tx.signed
 ```
 
-7. You can now submit the transaction to the chain:
+3. Submit the transaction to the chain:
 
 ```
 cardano-cli transaction submit \
@@ -78,17 +117,65 @@ cardano-cli transaction submit \
 
 **You have now submitted a constitution update governance action!**
 
-8. Next, you will require the action ID to share it with others on **Discord**[^1] and seek their support for your action. For now, the simplest method to obtain it is by querying the balance again. The earlier generated UTXO and index serve as the action ID:
+### Getting the governance action ID
+
+1. You need the action ID to share it with others on **Discord**[^1] and seek their support for your action. The simplest method to obtain it is by querying the balance again. The transaction ID and index of the transaction that submitted the constitution proposal serve as the action ID. Therefore, the command
 
 ```
 cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 4 --out-file /dev/stdout | jq -r 'keys[0]'
 ```
 
-You should get something like this:
+should provide the UTXO that created the constitution proposal:
 
 ```
-64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54#0
+9ab2df5d8076fed50720b83f5f7051c6019818270e2121817dc65758ae87ce99#0
 ```
+
+2. Sometimes, it might be helpful to query the ledger state to filter actions by a key hash:
+
+````
+keyhash=$(bech32 <<< $(cardano-cli stake-address build --stake-verification-key-file stake1.vkey --testnet-magic 4) | cut -c 3-)
+````
+
+````
+cardano-cli query ledger-state --testnet-magic 42 | jq -r --arg keyhash "$keyhash" '.stateBefore.esLState.utxoState.ppups.gov | to_entries[] | select(.value.returnAddr.credential."key hash" == $keyhash)'
+````
+````
+{
+  "key": "9ab2df5d8076fed50720b83f5f7051c6019818270e2121817dc65758ae87ce99#0",
+  "value": {
+    "committeeVotes": [],
+    "dRepVotes": [],
+    "stakePoolVotes": {},
+    "deposit": 1000000,
+    "returnAddr": {
+      "credential": {
+        "key hash": "754784f0d8555842fb27df356b56b6534f0c58fa62af76836012bfc6"
+      },
+      "network": "Testnet"
+    },
+    "action": {
+      "contents": [
+        null,
+        {
+          "constitutionAnchor": {
+            "dataHash": "3d2a9d15382c14f5ca260a2f5bfb645fe148bfe10c1d0e1d305b7b1393e2bd97",
+            "url": "https://shorturl.at/asIJ6"
+          }
+        }
+      ],
+      "tag": "NewConstitution"
+    },
+    "proposedIn": 2
+  }
+}
+````
+Similarly, to get **only** the key (the action ID) after the query, run:
+````
+cardano-cli query ledger-state --testnet-magic 42 | jq -r --arg keyhash "$keyhash" '.stateBefore.esLState.utxoState.ppups.gov | to_entries[] | select(.value.returnAddr.credential."key hash" == $keyhash) | .key'
+
+9ab2df5d8076fed50720b83f5f7051c6019818270e2121817dc65758ae87ce99#0
+````
 
 See the [Voting tutorial](./vote-actions.mdx) to find out how to vote on governance actions.
 

--- a/docs/tutorials/create-action.mdx
+++ b/docs/tutorials/create-action.mdx
@@ -5,7 +5,7 @@ sidebar_position: 8
 slug: /tutorials/create-action
 ---
 
-* Cardano node and Cardano CLI v.8.3.0-pre bring the ability for **any stake key** to create goveranance actions.
+* Cardano node and Cardano CLI v.8.3.0-pre bring the ability for **any stake key** to create governance actions.
 
 ### Pre-requisites
 

--- a/docs/tutorials/delegate-to-drep.mdx
+++ b/docs/tutorials/delegate-to-drep.mdx
@@ -1,0 +1,80 @@
+---
+sidebar_label: Delegate votes to a DRep
+title: Delegate votes to a DRep
+sidebar_position: 7
+slug: /tutorials/delegate-to-drep
+---
+
+Delegating your voting power to a SanchoNet delegate representative (DRep) operates much like delegating your stake to a stake pool. Voting power delegation involves the issuance of a delegation certificate from your stake key to the chosen SanchoNet DRep. Just as with stake delegation, the process of delegating votes to a SanchoNet DRep does not entail relinquishing control of your funds. Instead, the vote delegation certificate grants the selected DRep permission to vote on your behalf.
+
+In addition to the registered SanchoNet DReps, the system features a couple of default DReps:
+
+* --always-abstain: this option signals your intention not to participate in the voting procedures, indicating a choice to abstain from the voting process
+
+* --always-no-confidence: this option signifies your lack of trust in the current constitutional committee, indicating a vote of no confidence in their decisions
+
+### Prerequisites
+
+* Payment keys and address with funds
+* Stake key
+* Default SanchoNet DRep selection: `--always-abstain` or `--always-no-confidence`
+* SanchoNet DRep ID (or verification key) of a registered DRep
+* A SanchoNet node
+
+### Generating the vote delegation certificate
+
+1. Generate the vote delegation certificate.
+
+* Delegating to the `--always-abstain` default DRep:
+
+````
+cardano-cli conway governance drep delegation-certificate \
+--stake-verification-key-file stake.vkey \
+--always-abstain \
+--out-file vote-deleg.cert
+````
+
+* Delegating to a registered SanchoNet DRep:
+
+````
+cardano-cli conway governance drep delegation-certificate \
+--stake-verification-key-file stake.vkey \
+--drep-key-hash $(cat drep.id) \
+--out-file vote-deleg.cert
+````
+
+### Submitting the certificate in a transaction
+
+1. Submit the vote delegation certificate in a transaction.
+
+* Build:
+
+```
+cardano-cli transaction build \
+--conway-era \
+--testnet-magic 4 \
+--witness-override 2 \
+--tx-in $(cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 4 --out-file  /dev/stdout | jq -r 'keys[0]') \
+--change-address $(cat payment.addr) \
+--certificate-file vote-deleg.cert \
+--out-file tx.raw
+```
+
+* Sign with payment and stake keys:
+
+```
+cardano-cli transaction sign \
+--tx-body-file tx.raw \
+--signing-key-file payment.skey \
+--signing-key-file stake.skey \
+--testnet-magic 4 \
+--out-file tx.signed
+```
+
+* Submit:
+
+```
+cardano-cli transaction submit \
+--testnet-magic 4 \
+--tx-file tx.signed
+```

--- a/docs/tutorials/file-naming-convention.mdx
+++ b/docs/tutorials/file-naming-convention.mdx
@@ -1,29 +1,33 @@
 ---
-sidebar_label: Voting 
+sidebar_label: File naming convention
 title: File naming convention/schema
-sidebar_position: 7
+sidebar_position: 1
 slug: /tutorials/file-naming-convention
 ---
 
-To align the tutorials, examples and also 3rd-party tooling, you can find a suggested file naming convention/schema related to Conway/Voltaire Era in this document.
+To align the tutorials, examples, and also third-party tooling, you can find a suggested file naming convention/schema related to the Conway and Voltaire eras in this document.
 
-The schemas can be extended with a `*.` prefix if needed, here is an example:
+The schemas can be extended with a `*.` prefix if needed. For example:
+
 - Suggested file name: `drep.skey`
 - Extended with a prefix: `myname.drep.skey`
 
-As this is all work in progress, please revisit this page regulary to see if any new or changed schemas were selected.
+The naming convention is a work in progress. Please revisit this page regularly to check if any new or modified schemas have been selected.
 
-## Constitution Files
+### Constitution files
 
-Below is a list of currently used files related to the Constitution Text-Content/Action/Vote.
+Below is a list of currently used files related to the constitution's text-content/action/vote.
 
-### Text / Content
+#### Text/content
+
 `constitution.txt / *.constitution.txt` constitution in cleartext utf-8
 
-### Action
-`constitution.action / *.constitution.action` for action file content in json
+#### Action
+
+`constitution.action / *.constitution.action` for action file content in JSON
 
 Example content:
+
 ```json
 {
     "type": "Governance proposal",
@@ -32,10 +36,11 @@ Example content:
 }
 ```
 
-### Vote
-`constitution.vote / *.constitution.vote` for the vote ballot in json
+#### Vote
+`constitution.vote / *.constitution.vote` for the vote ballot in JSON
 
 Example content:
+
 ```json
 {
     "type": "Governance vote",
@@ -44,16 +49,17 @@ Example content:
 }
 ```
 
+### SanchoNet delegate representatives (DReps) files
 
-## Delegate representatives (DReps) Files
+Below is a list of currently used files related to SanchoNet DRep usage.
 
-Below is a list of currently used files related to a Delegate Representative usage.
+#### Signing key
 
-### Signing Key
-Generated as a normal ed25519 key or derived from path `1852'/1815'/acc'/3/idx'` 
-`drep.skey / *.drep.skey` for the drep secret-key json (content like below)
+Generated as a normal ed25519 key or derived from path `1852'/1815'/acc'/3/idx'`
+`drep.skey / *.drep.skey` for the SanchoNet DRep secret-key JSON (see example content below)
 
 Example content:
+
 ```json
 {
     "type": "DRepSigningKey_ed25519",
@@ -66,13 +72,14 @@ Example content:
     "cborHex": "5840d84f8646463b03accf....da82c5dba3b1e4aa0df20b7"
 }
 ```
-The keys derived from hardware wallets will have the keyword 'Hardware' in the description field like:
-`Hardware Delegate Representative Signing Key`
+The keys derived from hardware wallets will have the keyword 'Hardware' in the description field, such as: 'Hardware Delegate Representative Signing Key'.
 
-### Verification Key
-`drep.vkey / *.drep.vkey` for the drep verification-key json (content like below)
+#### Verification key
+
+`drep.vkey / *.drep.vkey` for the SanchoNet DRep verification-key JSON (see example content below)
 
 Example content:
+
 ```json
 {
     "type": "DRepVerificationKey_ed25519",
@@ -85,19 +92,23 @@ Example content:
     "cborHex": "5820fd6b3cda64cf11f9b91ea3c88dffed906bc872f1e24566d68637c718788638d9"
 }
 ```
-The keys derived from hardware wallets will have the keyword 'Hardware' in the description field like:
-`Hardware Delegate Representative Verification Key`
 
-### Identification File (ID)
-`drep.id / *.drep.id` for the drep id in bech format `drep_id1...`
+The keys derived from hardware wallets will have the keyword 'Hardware' in the description field, such as: `Hardware Delegate Representative Verification Key`
+
+#### Identification file (ID)
+
+`drep.id / *.drep.id` for the DRep ID in bech format `drep_id1...`
 
 Example content:
+
 `drep_id12dggdndq3hhjzszukw5k5sulsesjux780s39h087s0p9vk6ylra`
 
-### Registration Certificate
-`drep-reg.cert / *.drep-reg.cert` for the registration certificate json
+#### Registration certificate
+
+`drep-reg.cert / *.drep-reg.cert` for the registration certificate JSON
 
 Example content:
+
 ```json
 {
     "type": "CertificateConway",
@@ -106,10 +117,12 @@ Example content:
 }
 ```
 
-### Retirement Certificate
-`drep-ret.cert / *.drep-ret.cert` for the de-registration/retirement certificate json
+#### Retirement certificate
+
+`drep-ret.cert / *.drep-ret.cert` for the de-registration/retirement certificate JSON
 
 Example content:
+
 ```json
 {
     "type": "CertificateConway",
@@ -118,32 +131,36 @@ Example content:
 }
 ```
 
-### Vote Delegation Certificate
-`vote-deleg.cert / *.vote-deleg.cert` for the vote delegation certificate json
+#### Vote delegation certificate
+
+`vote-deleg.cert / *.vote-deleg.cert` for the vote delegation certificate JSON
 
 Example content:
+
 ```json
-{ 
+{
 	"type": "CertificateConway",
 	"description": "Vote Delegation Certificate",
 	"cborHex": "83098200581cc827e7d1fb57cf12662203612fe1f0bb3578574b16f90f4a78cd355c8200581c44924d8233e23a4eda97ba2ce0a336d6152171e70960396b4903eb8a"
 }
 ```
 
-## Constitution Commitee Files
+### Constitution committee files
 
-Below is a list of currently used files retated to the Constitution Commitee Member usage.
+Below is a list of currently used files related to the constitution committee member usage.
 
-### Signing Key (Cold)
-`cc-cold.skey / *.cc-cold.skey` for the cold constitutional commitee member secret-key json
+#### Signing key (cold)
 
-### Signing Key (Hot)
-`cc-hot.skey / *.cc-hot.skey` for the hot constitutional commitee member secret-key json
+`cc-cold.skey / *.cc-cold.skey` for the cold constitutional committee member secret-key JSON
 
-### Verification Key (Cold)
-`cc-cold.vkey / *.cc-cold.vkey` for the cold constitutional commitee member verification-key json
+#### Signing key (hot)
 
-### Verification Key (Hot)
-`cc-hot.vkey / *.cc-hot.vkey` for the hot constitutional commitee member verification-key json
+`cc-hot.skey / *.cc-hot.skey` for the hot constitutional committee member secret-key JSON
 
+#### Verification key (cold)
 
+`cc-cold.vkey / *.cc-cold.vkey` for the cold constitutional committee member verification-key JSON
+
+#### Verification key (hot)
+
+`cc-hot.vkey / *.cc-hot.vkey` for the hot constitutional committee member verification-key JSON

--- a/docs/tutorials/keys-and-address.mdx
+++ b/docs/tutorials/keys-and-address.mdx
@@ -1,10 +1,19 @@
 ---
-sidebar_label: Create keys and the address
-sidebar_position: 2
+sidebar_label: Generate keys and the address
+title: Generate keys and address
+sidebar_position: 3
 slug: /tutorials/address
 ---
 
-# Create your keys and the SanchoNet address 
+First, generate a payment key pair and a stake key pair. Then, use the payment verification key and the stake verification key to build an address which can be used to receive funds from the faucet.
+
+The payment keys control the funds, while the stake keys control the participation in the protocol: delegating stake to a pool and delegating votes to a delegate representative.
+
+### Pre-requisites
+
+* cardano-cli installed
+
+### Generate key pairs
 
 1. Generate payment keys:
 
@@ -20,7 +29,9 @@ cardano-cli address key-gen \
 cardano-cli stake-address key-gen \
 --verification-key-file stake.vkey \
 --signing-key-file stake.skey
-```     
+```
+
+### Build the address
 
 3. Build your address:
 
@@ -30,4 +41,8 @@ cardano-cli address build \
 --stake-verification-key-file stake.vkey \
 --out-file payment.addr \
 --testnet-magic 4
-``` 
+```
+
+### Get funds from the faucet
+
+4. Use your address on the [faucet](faucet.mdx) to get SanchoNet tAda

--- a/docs/tutorials/keys-and-address.mdx
+++ b/docs/tutorials/keys-and-address.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Generate keys and the address
+sidebar_label: Generate keys and an address
 title: Generate keys and address
 sidebar_position: 3
 slug: /tutorials/address

--- a/docs/tutorials/register-drep.mdx
+++ b/docs/tutorials/register-drep.mdx
@@ -1,0 +1,126 @@
+---
+sidebar_label: Register a DRep
+title: Registering as a SanchoNet delegate representative (DRep)
+sidebar_position: 6
+slug: /tutorials/drep-registration
+---
+
+### Pre-requisites
+
+* Payment address with funds
+* A SanchoNet node
+
+### Generate SanchoNet DRep keys and an ID
+
+1. Generate a DRep key pair:
+
+````
+cardano-cli conway governance drep key-gen \
+--verification-key-file drep.vkey drep.vkey \
+--signing-key-file drep.skey drep.skey
+````
+
+````
+{
+    "type": "DRepSigningKey_ed25519",
+    "description": "Delegate Representative Signing Key",
+    "cborHex": "5820eba7053fdc9cb3b8aacf142d3d4ad575bb48fb92f4082d81605ac8e2ccfead5d"
+}
+````
+````
+{
+    "type": "DRepVerificationKey_ed25519",
+    "description": "Delegate Representative Verification Key",
+    "cborHex": "5820c19e0e939609531cfd04dcfa5bf1a5f3e245aa88e163759341aba296af34cc7e"
+}
+````
+
+2. Generate a SanchoNet DRep ID:
+
+````
+cardano-cli conway governance drep id
+--drep-verification-key-file drep.vkey \
+--out-file drep.id
+````
+````
+drep124w9k5ml25kcshqet8r3g2pwk6kqdhj79thg2rphf5u5urve0an
+````
+
+### Generate the registration certificate
+
+1. Create a SanchoNet DRep registration certificate
+
+There are three ways to generate the certificate:
+
+* Using the drep.vkey file:
+
+````
+cardano-cli conway governance drep registration-certificate \
+--drep-verification-key-file drep.vkey \
+--key-reg-deposit-amt 0 \
+--out-file drep-register.cert
+````
+
+* Using the DRep verification key:
+
+````
+cardano-cli conway governance drep registration-certificate \
+--drep-verification-key "$(cat drep.vkey | jq -r .cborHex | cut -c 5-)" \
+--key-reg-deposit-amt 0 \
+--out-file drep-register.cert
+````
+
+* Using the DRep ID:
+
+````
+cardano-cli conway governance drep registration-certificate \
+--drep-key-hash $(cat drep.id) \
+--key-reg-deposit-amt 0 \
+--out-file drep-register.cert
+````
+
+Any of the above methods produces drep-register.cert, which contains:
+
+````
+{
+    "type": "CertificateShelley",
+    "description": "DRep Key Registration Certificate",
+    "cborHex": "84108200581c555c5b537f552d885c1959c714282eb6ac06de5e2aee850c374d394e00f6"
+}
+````
+
+### Submit certificate in a transaction
+
+1. Submit the SanchoNet DRep registration certificate in a transaction.
+
+* Build:
+
+```
+cardano-cli transaction build \
+--conway-era \
+--testnet-magic 4 \
+--witness-override 2 \
+--tx-in $(cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 4 --out-file  /dev/stdout | jq -r 'keys[0]') \
+--change-address $(cat payment.addr) \
+--certificate-file drep-register.cert \
+--out-file tx.raw
+```
+
+* Sign:
+
+```
+cardano-cli transaction sign \
+--tx-body-file tx.raw \
+--signing-key-file payment.skey \
+--signing-key-file drep.skey \
+--testnet-magic 4 \
+--out-file tx.signed
+```
+
+* Submit:
+
+```
+cardano-cli transaction submit \
+--testnet-magic 4 \
+--tx-file tx.signed
+```

--- a/docs/tutorials/register-spo.mdx
+++ b/docs/tutorials/register-spo.mdx
@@ -183,7 +183,7 @@ cardano-cli node key-gen-VRF \
 ```
 
 
-### Generate the registraton and delegation certificates for the pool
+### Generate the registration and delegation certificates for the pool
 
 8. Create your stake pool registration certificate:
 

--- a/docs/tutorials/register-spo.mdx
+++ b/docs/tutorials/register-spo.mdx
@@ -1,12 +1,11 @@
 ---
 sidebar_label: Register a stake pool
-title: Register a stake pool in SanchoNet 
-sidebar_position: 4
+title: Register a stake pool
+sidebar_position: 5
 slug: /tutorials/stake-pool-registration
 ---
 
-**WARNING**: This tutorial is simplified and deliberately excludes secure key handling which is essential for other testnets 
-and mainnet. For a comprehensive tutorial, see the [Cardano course](https://cardano-course.gitbook.io/cardano-course/) where you can access video lessons and a more detailed instruction handbook.
+**WARNING**: This tutorial is simplified and deliberately excludes secure key handling which is essential for other testnets and mainnet. For a comprehensive tutorial, see the [Cardano course](https://cardano-course.gitbook.io/cardano-course/) where you can access video lessons and a more detailed instruction handbook.
 
 ### Prerequisites
 
@@ -14,13 +13,11 @@ Before you start, ensure that you are familiar with:
 
 1. Running a node: [see the tutorial](start-a-node.mdx)
 2. Created keys and addresses: [see the tutorial](keys-and-address.mdx)
-3. Requested funds from the faucet: [see the tutorial](faucet.mdx)
+3. Requested funds from the [faucet:](faucet.mdx)
 
 ### Set up a relay node
 
-Setting up a stake pool on SanchoNet involves configuring a block producer node and at least one relay node. The relay node plays a crucial
-role in propagating the blocks forged by your block-producing node, as well as fetching blocks from other stake pools and serving them to your block producer. In this structure, 
-the block producer communicates solely with your relay node, which in turn interfaces with the rest of the network. This ensures a streamlined communication process and helps to secure your block producer. 
+Setting up a stake pool on SanchoNet involves configuring a block producer node and at least one relay node. The relay node plays a crucial role in propagating the blocks forged by your block-producing node, as well as fetching blocks from other stake pools and serving them to your block producer. In this structure, the block producer communicates solely with your relay node, which in turn interfaces with the rest of the network. This ensures a streamlined communication process and helps to secure your block producer.
 
 The typical configuration of the stake pool should resemble the following:
 
@@ -28,13 +25,11 @@ The typical configuration of the stake pool should resemble the following:
 
 To set up your relay node, carry out the following steps:
 
-1. **Install the Cardano node and the Cardano CLI** on your relay node. 
+1. **Install the Cardano node and the Cardano CLI** on your relay node.
 
-2. **Configure the firewall for incoming connections**: set up the firewall to accept incoming connections on the 
-specific port that you'll be using for the Cardano node. This allows other nodes, including your block producer, to communicate with your relay.
+2. **Configure the firewall for incoming connections**: set up the firewall to accept incoming connections on the specific port that you'll be using for the Cardano node. This allows other nodes, including your block producer, to communicate with your relay.
 
-3. **Configure the firewall for outgoing connections**: enable the firewall to allow outgoing connections. This configuration ensures 
-that your relay node can contact other relay nodes in the network as well as your block producer node. 
+3. **Configure the firewall for outgoing connections**: enable the firewall to allow outgoing connections. This configuration ensures that your relay node can contact other relay nodes in the network as well as your block producer node.
 
 4. **Run the node with P2P topology**: start your node using the P2P topology setting.
 
@@ -63,18 +58,18 @@ that your relay node can contact other relay nodes in the network as well as you
 ```
 
 
-### Set up a block producer 
+### Set up a block producer
 
-Setting up your block producer involves similar steps, but there are a few differences in the configuration: 
+Setting up your block producer involves similar steps, but there are a few differences in the configuration:
 
-1. **Install the Cardano node and the Cardano CLI** on your block producer node. 
+1. **Install the Cardano node and the Cardano CLI** on your block producer node.
 
-2. **Configure the firewall for incoming connections**: set up the firewall to accept incoming connections **only from your relay node** on the 
+2. **Configure the firewall for incoming connections**: set up the firewall to accept incoming connections **only from your relay node** on the
 specific port that you'll be using for the Cardano node. This ensures that only your relay node can communicate with your block producer.
 
-3. **Configure the firewall for outgoing connections**: enable the firewall to allow outgoing connections, preferably, **only to your own relay's IP and port**. 
+3. **Configure the firewall for outgoing connections**: enable the firewall to allow outgoing connections, preferably, **only to your own relay's IP and port**.
 
-4. **Run the node with P2P topology**: start your node using the P2P topology configuration. This time, replace **"address":"x.x.x.x"** and **"port":3000** with the actual IP address 
+4. **Run the node with P2P topology**: start your node using the P2P topology configuration. This time, replace **"address":"x.x.x.x"** and **"port":3000** with the actual IP address
 and the port of your **own relay node**. Note that the block producer does not connect to `sanchonet-node.world.dev.cardano.org` and we avoid using ledger peers by setting `"useLedgerAfterSlot¨`to `-1`
 
 ```
@@ -101,7 +96,7 @@ and the port of your **own relay node**. Note that the block producer does not c
    "useLedgerAfterSlot":-1
 }
 ```
-### Register your stake pool
+### Install jq and set the node socket path
 
 1. Install [jq](https://jqlang.github.io/jq), a tool that will assist in parsing the UTXOs for transactions:
 
@@ -109,11 +104,13 @@ and the port of your **own relay node**. Note that the block producer does not c
 sudo apt-get install jq -y
 ````
 
-2. Set the `CARDANO_NODE_SOCKET_PATH` variable to the path of `node.socket` that you identified when starting the node:  
+2. Set the `CARDANO_NODE_SOCKET_PATH` variable to the path of `node.socket` that you identified when starting the node:
 
 ```
 export CARDANO_NODE_SOCKET_PATH=~/node.socket
 ```
+
+### Register the stake address
 
 3. Register the stake address you previously created by generating a registration certificate:
 
@@ -155,8 +152,10 @@ cardano-cli transaction sign \
 ```
 cardano-cli transaction submit \
 --testnet-magic 4 \
---tx-file tx.signed 
+--tx-file tx.signed
 ```
+
+### Generate keys for the stake pool
 
 5. Generate cold keys and the operational certificate for your pool:
 
@@ -182,6 +181,9 @@ cardano-cli node key-gen-VRF \
 --verification-key-file vrf.vkey \
 --signing-key-file vrf.skey
 ```
+
+
+### Generate the registraton and delegation certificates for the pool
 
 8. Create your stake pool registration certificate:
 
@@ -211,7 +213,9 @@ cardano-cli stake-address delegation-certificate \
 --out-file delegation.cert
 ```
 
-10. Submit pool registration and stake delegation certificates:
+### Submit the certificates in a transaction
+
+10. Build, sign and submit the transaction
 
 * Build:
 
@@ -244,7 +248,7 @@ cardano-cli transaction sign \
 ```
 cardano-cli transaction submit \
 --testnet-magic 4 \
---tx-file tx.signed 
+--tx-file tx.signed
 ```
 
 11. Get your pool ID, you will need to get a delegation from the faucet:
@@ -256,7 +260,9 @@ cardano-cli stake-pool id \
 --out-file pool.id
 ```
 
-12. Generate you operation certificate:
+### Starting the node as a block-producer
+
+12. Generate your operational certificate:
 
 ```
 slotsPerKESPeriod=$(cat shelley-genesis.json | jq -r '.slotsPerKESPeriod')
@@ -294,7 +300,3 @@ cardano-cli query stake-snapshot \
 ```
 grep -e TraceForgedBlock
 ```
-
-
-
-

--- a/docs/tutorials/register-stake.md
+++ b/docs/tutorials/register-stake.md
@@ -1,0 +1,17 @@
+---
+sidebar_label: Stake address registration
+title: Stake address registration certificate
+sidebar_position: 4
+slug: /tutorials/register-stake-address
+---
+
+To take part on the protocol we need to submit a stake address registration certificate.
+
+### Pre-requisites
+
+* Stake key pair
+* Payment key pair
+* Address with funds
+* A SanchoNet node
+
+### Generate the registration certificate

--- a/docs/tutorials/register-stake.md
+++ b/docs/tutorials/register-stake.md
@@ -5,7 +5,8 @@ sidebar_position: 4
 slug: /tutorials/register-stake-address
 ---
 
-To take part on the protocol we need to submit a stake address registration certificate.
+To take part on the SanchoNet consensus protocol, we need to submit a stake address registration certificate to the chain. This allows to delegate stake to a SanchoNet stake pool
+and votes to a SanchoNet delegate representative (DRep).
 
 ### Pre-requisites
 
@@ -15,3 +16,48 @@ To take part on the protocol we need to submit a stake address registration cert
 * A SanchoNet node
 
 ### Generate the registration certificate
+
+1. Register the stake address you previously created by generating a registration certificate:
+
+```
+cardano-cli stake-address registration-certificate \
+--stake-verification-key-file stake.vkey \
+--key-reg-deposit-amt 2000000 \
+--out-file registration.cert
+```
+
+### Submit the certificate to the chain
+
+2. Build, sign and submit the transaction.
+
+* **Build** the transaction:
+
+```
+cardano-cli transaction build \
+--conway-era \
+--testnet-magic 4 \
+--witness-override 2 \
+--tx-in $(cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 4 --out-file  /dev/stdout | jq -r 'keys[0]') \
+--change-address $(cat payment.addr) \
+--certificate-file registration.cert \
+--out-file tx.raw
+```
+
+* **Sign** the transaction:
+
+```
+cardano-cli transaction sign \
+--tx-body-file tx.raw \
+--signing-key-file payment.skey \
+--signing-key-file stake.skey \
+--testnet-magic 4 \
+--out-file tx.signed
+```
+
+* **Submit** the transaction:
+
+```
+cardano-cli transaction submit \
+--testnet-magic 4 \
+--tx-file tx.signed
+```

--- a/docs/tutorials/start-a-node.mdx
+++ b/docs/tutorials/start-a-node.mdx
@@ -1,14 +1,13 @@
 ---
-sidebar_label: Start a node
-sidebar_position: 1
+sidebar_label: Start a SanchoNet node
+title: Start a SanchoNet node
+sidebar_position: 2
 slug: /tutorials/start-node
 ---
 
-# Start a node
+### Download or build cardano-node and cardano-cli binaries:
 
-### Download or build cardano-node and cardano-cli binaries
-
-* Latest release [8.2.1-pre](https://github.com/input-output-hk/cardano-node/releases/tag/8.2.1-pre)
+* The latest version for SanchoNet is **8.3.0-pre**. [See releases](https://github.com/input-output-hk/cardano-node/releases)
 
 ### Get configuration files
 
@@ -28,7 +27,7 @@ cardano-node run --topology topology.json \
 --database-path db \
 --socket-path node.socket \
 --port 3001 \
---config config.json 
+--config config.json
 ```
 
 ### Need help?

--- a/docs/tutorials/vote-actions.mdx
+++ b/docs/tutorials/vote-actions.mdx
@@ -1,41 +1,121 @@
 ---
-sidebar_label: Voting 
-title: Voting governance actions
-sidebar_position: 6
+sidebar_label: Voting on actions
+title: Voting on governance actions
+sidebar_position: 9
 slug: /tutorials/vote-action
 ---
 
+### Pre-requisites
+
+* Payment key pair
+* Address with funds
+* DRep OR Stake pool keys
+* A SanchoNet node
+
 To vote on governance actions, follow this process:
 
-1. Obtain the action ID of an ongoing governance action from Discord
+1. Obtain the action ID of an ongoing governance action from Discord or query the ledger
 2. Determine your voting stance; engage in discussion if required
-3. Construct your vote file through the Cardano CLI. The example below demonstrates voting `--yes`, although options for `--no` or `--abstain` are also available. 
+3. Construct your vote file through the Cardano CLI. The example below demonstrates voting `--yes`, although options for `--no` or `--abstain` are also available.
 
-Create your vote file, note that `--tx-in` refers to the action ID:
+### Verify the content of the governance action
+
+Assume that we have been given the action ID `8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da#0` for a new constitution proposal.
+
+1. Obtain the URL and hash of the new constitution proposal from the ledger state:
+
+````
+cardano-cli query ledger-state --testnet-magic 4 | \
+jq -r --arg key_to_match "8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da#0" \
+'.stateBefore.esLState.utxoState.ppups.gov | select(.[$key_to_match] != null) | {($key_to_match): .[$key_to_match]}'
+````
+````
+{
+  "8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da#0": {
+    "committeeVotes": [],
+    "dRepVotes": [],
+    "stakePoolVotes": {},
+    "deposit": 1000000,
+    "returnAddr": {
+      "credential": {
+        "key hash": "51330288da94527431d242993fa1f73ec4043549a073e1cfba9db3bf"
+      },
+      "network": "Testnet"
+    },
+    "action": {
+      "contents": [
+        null,
+        {
+          "constitutionAnchor": {
+            "dataHash": "3d2a9d15382c14f5ca260a2f5bfb645fe148bfe10c1d0e1d305b7b1393e2bd97",
+            "url": "https://shorturl.at/asIJ6"
+          }
+        }
+      ],
+      "tag": "NewConstitution"
+    },
+    "proposedIn": 1
+  }
+}
+````
+2. Download the file from the URL registered on the ledger state:
+
+````
+wget https://shorturl.at/asIJ6 -O constitution.txt
+````
+
+3. Verify that the hash of the file matches the `dataHash`from the ledger state:
+
+````
+b2sum -l 256 constitution.txt
+3d2a9d15382c14f5ca260a2f5bfb645fe148bfe10c1d0e1d305b7b1393e2bd97  constitution.txt
+````
+
+**Everything is in order; the text at the URL matches the dataHash, confirming that the text at the URL is precisely what we are voting for.**
+
+In the future, voting apps, explorers, wallets, and other tools could perform the filtering, ensuring that they only display actions whose URL content has been verified against the hash on the ledger state.
+
+### Create the vote file
+
+1. Vote with DRep keys
 
 ```
-cardano-cli governance vote create-vote \
+cardano-cli conway governance vote create \
     --yes \
-    --spo \
-    --tx-in "64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54#0" \
-    --cold-verification-key-file cold.vkey \
-    --conway-era \
-    --out-file 64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54.vote
+    --governance-action-tx-id "8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da" \
+    --governance-action-index "0" \
+    --drep-verification-key-file drep.vkey \
+    --out-file 8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da-constitution.vote
 ```
 
-Include it in a transaction:
+OR
+
+2. Vote with SPO keys
+
+```
+cardano-cli conway governance vote create \
+    --yes \
+    --governance-action-tx-id "8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da" \
+    --governance-action-index "0" \
+    --cold-verification-key-file cold.vkey \
+    --out-file 8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da-constitution.vote
+```
+
+### Include the vote in a transaction:
+
+1. Build, sign, and submit the transaction:
 
 ```
 cardano-cli transaction build --testnet-magic 4 --conway-era \
     --tx-in "$(cardano-cli query utxo --address $(cat payment.addr) --testnet-magic 4 --out-file /dev/stdout | jq -r 'keys[0]')" \
     --change-address $(cat payment.addr) \
-    --vote-file 64e7cad9b3ece7451c5b12043bdcdaa3c563392fa97eb9f2cec02fe821dffa54.vote \
+    --vote-file 8a02dfbd297afbcb32e72fa94117f3e255100c1cb5c083e84e1c977ed5aca0da-constitution.vote \
     --witness-override 2 \
     --out-file vote-tx.raw
 ```
 ```
 cardano-cli transaction sign --tx-body-file vote-tx.raw \
-    --signing-key-file cold.skey \
+    --signing-key-file drep.skey \
     --signing-key-file payment.skey \
     --testnet-magic 4 \
     --out-file vote-tx.signed


### PR DESCRIPTION
Soon we will have 8.3.0-pre available for SanchoNet. This will bring some changes to the CLI,  therefore we need to update the tutorials. Key changes: 

- Any stake key can create a governance action, not only spos as before
- We can register/unregister DReps  in SanchoNet
- Vote delegation to DReps is now possible in SanchoNet
- Voting as DRep is now possible  in SanchoNet
- No need to specify the role when issuing a vote, it is now automatically derived from the key type. 
- Adding query to ledger state to get information about governance actions (next release will bring specific queries) 
- Outline how to validate that the URL and the HASH of a governance action match