### PR TITLE
Adding a YouTube Sanchonet Guides playlist

### DIFF
--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -53,5 +53,6 @@ Disclaimer: These tools and guides are created by the community and are not supp
 ### Guides from the community:
 
 | Author                        | Title                                                                                              | Date       |                                                                                                                                                                      |
-|-------------------------------|----------------------------------------------------------------------------------------------------|------------|
-|Eysteinh (NBX)                 | [Sancho Panza: Navigating Cardano's Testnet Frontier](https://www.youtube.com/watch?v=9CR8c9ZIVEE) | 2023-08-14 |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------|------------|
+|Eysteinh (NBX)                 | [Sancho Panza: Navigating Cardano's Testnet Frontier](https://www.youtube.com/watch?v=9CR8c9ZIVEE)                           | 2023-08-14 |
+|Mike Hornan (ABLE)             | [Sancho Testnet Guides and Command Line Interface](https://www.youtube.com/playlist?list=PLWYf5eQbRdbWa5n21tyy8xWpTS6zjm3Mj) | 2023-10-02 |


### PR DESCRIPTION
* Added Sancho Testnet Guides and Command Line Interface playlist to the Guides from the community.
* I think this is appropriate to have a link to the playlist to avoid having to make a PR every time we make a new video about the Sancho testnet.