### PR TITLE
Docs: Updated resources page

### DIFF
--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -29,7 +29,7 @@ sidebar_position: 1
 
 CIP-95 is the governance extension to the CIP-30 wallet-DApp bridge.
 
-* [CIP-0095 | Web-Wallet Bridge - Governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0095/README.md)
+* [CIP-0095 | Web-wallet bridge – governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0095/README.md)
 * [Demos CIP-95 test DApp hosted](https://ryun1.github.io/cip95-cardano-wallet-connector/)
 * [Demos DApp source code](https://github.com/Ryun1/cip95-cardano-wallet-connector)
 * [Demos CIP-95 prototype wallet](https://github.com/Ryun1/cip95-demos-wallet)

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -37,7 +37,7 @@ CIP-95 is the governance extension to the CIP-30 wallet-DApp bridge.
 
 CIP-???? | Conway era key chains for HD wallets: describes how wallets can create the keys needed for users to engage with governance.
 
-* [Pull Request](https://github.com/cardano-foundation/CIPs/pull/597)
+* [Pull request](https://github.com/cardano-foundation/CIPs/pull/597)
 * [Rendered](https://github.com/Ryun1/CIPs/blob/conway-keys/CIP-conway-keys/README.md)
 
 ### Cardano Serialization Library (Conway Alpha) - Emurgo

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -4,12 +4,15 @@ title: 'Tools and resources'
 sidebar_position: 1
 ---
 
+*Last update: 2023-10-03*
+
 ### Node
 
 * [Latest node releases](https://github.com/input-output-hk/cardano-node/releases)
 
 ### Ledger
 
+* [CIP-1694 | A First Step Towards On-Chain Decentralized Governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md)
 * [Draft Conway design CDDL](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/conway/test-suite/cddl-files/conway.cddl)
 * [Conway ledger backlog](https://github.com/input-output-hk/cardano-ledger/issues?q=is%3Aissue+is%3Aopen+label%3Aconway)
 
@@ -26,20 +29,24 @@ sidebar_position: 1
 
 CIP-95 is the governance extension to the CIP-30 wallet-DApp bridge.
 
-* [CIP-0095? | web-wallet bridge: governance](https://github.com/cardano-foundation/CIPs/pull/509)
-* [CIP-0095 rendered on branch](https://github.com/Ryun1/CIPs/blob/governance-wallet-connector/CIP-0095/README.md)
+* [CIP-0095 | Web-Wallet Bridge - Governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0095/README.md)
 * [Demos CIP-95 test DApp hosted](https://ryun1.github.io/cip95-cardano-wallet-connector/)
 * [Demos DApp source code](https://github.com/Ryun1/cip95-cardano-wallet-connector)
 * [Demos CIP-95 prototype wallet](https://github.com/Ryun1/cip95-demos-wallet)
 * [WIP Nami CIP-95 PR](https://github.com/berry-pool/nami/pull/852)
 
+CIP-???? | Conway Era Key Chains for HD Wallets describes how wallets can create the keys needed for users to engage with governance.
+
+* [Pull Request](https://github.com/cardano-foundation/CIPs/pull/597)
+* [Rendered](https://github.com/Ryun1/CIPs/blob/conway-keys/CIP-conway-keys/README.md)
+
 ### Cardano Serialization Library (Conway Alpha) - Emurgo
 
 This is an Alpha build and the team are keen to hear feedback via [Github Issues](https://github.com/Emurgo/cardano-serialization-lib/issues).
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.6
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.6
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.6
-* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.6
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.7
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.7
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.7
+* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.7
 
 
 ## Built by the community

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -43,10 +43,10 @@ CIP-???? | Conway era key chains for HD wallets: describes how wallets can creat
 ### Cardano Serialization Library (Conway Alpha) - Emurgo
 
 This is an Alpha build and the team are keen to hear feedback via [Github Issues](https://github.com/Emurgo/cardano-serialization-lib/issues).
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.8
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.8
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.8
-* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.8
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.10
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.10
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.10
+* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.10
 
 
 ## Built by the community

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -18,10 +18,10 @@ sidebar_position: 1
 
 ### DB-Sync
 
-* [Sancho-1-1-0 build](https://github.com/input-output-hk/cardano-db-sync/releases/tag/sancho-1-1-0)
-* [Sancho-1-1-0 ChangeLog](https://github.com/input-output-hk/cardano-db-sync/blob/sancho-1-1-0/cardano-db-sync/CHANGELOG.md#13200)
-* [Sancho-1-1-0 schema docs](https://github.com/input-output-hk/cardano-db-sync/blob/sancho-1-1-0/doc/schema.md)
-* [Sancho-1-1-0 Postgres migrations](https://github.com/input-output-hk/cardano-db-sync/tree/sancho-1-1-0/schema)
+* [Sancho-2-0-0 build](https://github.com/input-output-hk/cardano-db-sync/releases/tag/sancho-2-0-0)
+* [Sancho-2-0-0 ChangeLog](https://gist.github.com/kderme/33174fdb2cba360ff6b5da72bd961bd8#200)
+* [Sancho-2-0-0 schema docs](https://github.com/input-output-hk/cardano-db-sync/blob/sancho-2-0-0/doc/schema.md)
+* [Sancho-2-0-0 Postgres migrations](https://github.com/input-output-hk/cardano-db-sync/tree/sancho-2-0-0/schema)
 * [Note on naming scheme](https://gist.github.com/kderme/2ab2f79fcdc159be3465bae9b7df78e7)
 * [Blog post on speeding up DB-Sync](https://github.com/input-output-hk/cardano-db-sync/blob/blog/blog/blog.pdf)
 

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 ### Ledger
 
-* [CIP-1694 | A First Step Towards On-Chain Decentralized Governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md)
+* [CIP-1694 | A first step towards on-chain decentralized governance](https://github.com/cardano-foundation/CIPs/blob/master/CIP-1694/README.md)
 * [Draft Conway design CDDL](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/conway/test-suite/cddl-files/conway.cddl)
 * [Conway ledger backlog](https://github.com/input-output-hk/cardano-ledger/issues?q=is%3Aissue+is%3Aopen+label%3Aconway)
 

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -35,7 +35,7 @@ CIP-95 is the governance extension to the CIP-30 wallet-DApp bridge.
 * [Demos CIP-95 prototype wallet](https://github.com/Ryun1/cip95-demos-wallet)
 * [WIP Nami CIP-95 PR](https://github.com/berry-pool/nami/pull/852)
 
-CIP-???? | Conway Era Key Chains for HD Wallets describes how wallets can create the keys needed for users to engage with governance.
+CIP-???? | Conway era key chains for HD wallets: describes how wallets can create the keys needed for users to engage with governance.
 
 * [Pull Request](https://github.com/cardano-foundation/CIPs/pull/597)
 * [Rendered](https://github.com/Ryun1/CIPs/blob/conway-keys/CIP-conway-keys/README.md)

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -43,10 +43,10 @@ CIP-???? | Conway era key chains for HD wallets: describes how wallets can creat
 ### Cardano Serialization Library (Conway Alpha) - Emurgo
 
 This is an Alpha build and the team are keen to hear feedback via [Github Issues](https://github.com/Emurgo/cardano-serialization-lib/issues).
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.7
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.7
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.7
-* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.7
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.8
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.8
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.8
+* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.8
 
 
 ## Built by the community


### PR DESCRIPTION
Updated the resources + tooling page:
- Added "Last update" note
- Added link to 1694
- Updated CIP-95 link to be the merged one
- Added link for new "DRep Keys CIP"
- Updated links to CSL alpha 10
- Added latest DB-Sync release