### PR TITLE
Docs: update resources page with CSL alpha 11

### DIFF
--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -4,7 +4,7 @@ title: 'Tools and resources'
 sidebar_position: 1
 ---
 
-*Last update: 2023-10-03*
+*Last update: 2023-10-16*
 
 ### Node
 
@@ -43,10 +43,10 @@ CIP-???? | Conway era key chains for HD wallets: describes how wallets can creat
 ### Cardano Serialization Library (Conway Alpha) - Emurgo
 
 This is an Alpha build and the team are keen to hear feedback via [Github Issues](https://github.com/Emurgo/cardano-serialization-lib/issues).
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.10
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.10
-* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.10
-* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.10
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-browser/v/12.0.0-alpha.11
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-nodejs/v/12.0.0-alpha.11
+* https://www.npmjs.com/package/@emurgo/cardano-serialization-lib-asmjs/v/12.0.0-alpha.11
+* https://crates.io/crates/cardano-serialization-lib/12.0.0-alpha.11
 
 
 ## Built by the community


### PR DESCRIPTION
## List of changes

- Changed the `/tools-resources/resources` to align with release of CSL alpha 11

## Screenshots of change (for frontend changes)

### Before

![scrnli_16_10_2023_21-20-10](https://github.com/input-output-hk/sanchonet/assets/44342099/664da237-3843-4ce5-b060-391e6c485afc)

### After

![scrnli_16_10_2023_21-15-38](https://github.com/input-output-hk/sanchonet/assets/44342099/ecfb5c45-357e-4630-88b7-21c898893390)
