### PR TITLE
Docs: Update stake registration deposit amount.

### DIFF
--- a/docs/tutorials/register-stake.mdx
+++ b/docs/tutorials/register-stake.mdx
@@ -22,7 +22,7 @@ and votes to a SanchoNet delegate representative (DRep).
 ```
 cardano-cli conway stake-address registration-certificate \
 --stake-verification-key-file stake.vkey \
---key-reg-deposit-amt 2000000 \
+--key-reg-deposit-amt $(cardano-cli conway query gov-state --testnet-magic 4 | jq -r .enactState.curPParams.keyDeposit) \
 --out-file registration.cert
 ```
 


### PR DESCRIPTION
The original value from genesis no longer works.
This reflects the up-to-date value since protocol change gov-action.

```bash
cardano-cli conway stake-address registration-certificate \
	--stake-verification-key-file stake.vkey \
	--key-reg-deposit-amt $(cardano-cli conway query gov-state --testnet-magic 4 | jq -r .enactState.curPParams.keyDeposit) \
	--out-file registration.cert
```

Thanks to [Mike Hornan from ABLE pool](https://twitter.com/Hornan7)