### PR TITLE
Update queries.mdx

### DIFF
--- a/docs/tutorials/queries.mdx
+++ b/docs/tutorials/queries.mdx
@@ -174,7 +174,7 @@ cardano-cli conway query committee-state --expired --testnet-magic 4
 ### Query active committee members
 
 ````
-cardano-cli conway query committee-state --active --testnet-magic 42
+cardano-cli conway query committee-state --active --testnet-magic 4
 {
     "committee": {
         "keyHash-059349cd1e77dc3e500d3ffc498adb7307001ecc022c8b083faaa48b": {


### PR DESCRIPTION
Line 177 had --testnet-magic 42

Extra number would confuse non-technical users, and it is important to remove it