### PR TITLE
Typo Corrections, and meetups

### DIFF
--- a/docs/meetups.md
+++ b/docs/meetups.md
@@ -4,6 +4,7 @@ SanchoNet meetups is a way for people to get to know more about SanchoNet be it 
 
 This page can be updated by anyone in the commmunity by submitting a pull request with changes.
 
-| Location | Date        | Link                                                                | Info                                                                          |
-|----------|-------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| Norway   |12. Nov 2023 |https://www.meetup.com/cardano-blockchain-oslo-no/events/296420885/  | SPO workshop hosted by NADA, https://twitter.com/NordicADA                    |
+| Location       | Date                               | Link                                                                | Info                                                                          |
+|----------------|------------------------------------|---------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| Norway         |12. Nov 2023                        |https://www.meetup.com/cardano-blockchain-oslo-no/events/296420885/  | SPO workshop hosted by NADA, https://twitter.com/NordicADA                    |
+| Discord(Online)|Every Thursdays 8:00PM EDT = (GMT-4)|https://discord.gg/tHYrxCtdHm                                        | SanchoNet CLI workshops for DReps hosted by Mike Hornan[ABLE]                 |

--- a/docs/tutorials/actions.mdx
+++ b/docs/tutorials/actions.mdx
@@ -30,7 +30,8 @@ You can get the last enacted governance action IDs with:
 
 ```
 cardano-cli conway query gov-state --testnet-magic 4 | jq -r .enactState.prevGovActionIds
-
+```
+```
 {
   "pgaCommittee": {
     "govActionIx": 0,
@@ -85,7 +86,7 @@ Create the governance action proposal:
 ```
 cardano-cli conway governance action update-committee \
   --testnet \
-  --governance-action-deposit 1000000000 \
+  --governance-action-deposit ${govActDeposit} \
   --stake-verification-key-file stake.vkey \
   --proposal-anchor-url https://tinyurl.com/3wrwb2as \
   --proposal-anchor-metadata-file rationale.txt \
@@ -143,6 +144,8 @@ the dedicated forum to explore the weighty matters of Cardano's constitution wit
 
 ```
 cardano-cli conway query gov-state --testnet-magic 4 | jq .enactState.prevGovActionIds.pgaConstitution
+```
+```
 {
   "govActionIx": 0,
   "txId": "00caeb6c2db4575acc43be3e8f87b881dccb86283daf16aa2707275cbe7f3451"
@@ -184,6 +187,8 @@ cardano-cli conway governance action create-constitution \
 
 ```
 cardano-cli conway query gov-state --testnet-magic 4 | jq -r '.enactState.prevGovActionIds.pgaCommittee'
+```
+```
 {
   "govActionIx": 0,
   "txId": "fe2c99fe6bc75a9666427163d51ae7dbf5a60df40135361b7bfd53ac6c7912ec"
@@ -241,7 +246,7 @@ cardano-cli conway governance action create-info --testnet \
   --proposal-anchor-url  https://tinyurl.com/yc74fxx4 \
   --proposal-anchor-metadata-file rationale.txt \
   --out-file info.action
-  ```
+```
 
 ## Submitting the `*.action` action file in a transaction
 
@@ -255,7 +260,7 @@ while also allowing members of the governance bodies to review, discuss, and ult
 cardano-cli conway transaction build \
   --testnet-magic 4 \
   --tx-in "$(cardano-cli query utxo --address "$(cat payment.addr)" --testnet-magic 4 --out-file /dev/stdout | jq -r 'keys[0]')" \
-  --tx-out $(cat payment.addr)+<lovelace> \
+  --change-address $(cat payment.addr) \
   --proposal-file info.action \
   --out-file tx.raw
 ```
@@ -282,14 +287,16 @@ First, find your key hash with:
 
 ```
 cardano-cli conway stake-address key-hash --stake-verification-key-file stake1.vkey
-8e0debc9fdc6c616ac40d98bf3950b436895eea9cccf0396a6e5e12b
 ```
+`8e0debc9fdc6c616ac40d98bf3950b436895eea9cccf0396a6e5e12b`
 
 Use `jq` to filter the `gov-state` output by the stake key hash. The output contains all the relevant information about your governance actions, including `actionId`:
 
 ```
 cardano-cli conway query gov-state --testnet-magic 4 \
 | jq -r --arg keyHash "8e0debc9fdc6c616ac40d98bf3950b436895eea9cccf0396a6e5e12b" '.proposals.psGovActionStates | to_entries[] | select(.value.returnAddr.credential.keyHash | contains($keyHash)) | .value'
+```
+```
 {
   "action": {
     "contents": [

--- a/docs/tutorials/vote-actions.mdx
+++ b/docs/tutorials/vote-actions.mdx
@@ -25,8 +25,8 @@ Assume that we have been given the action ID `df58f714c0765f3489afb6909384a16c31
 1. Obtain the URL and hash of the new constitution proposal from the governance state:
 
 ```
-cardano-cli conway governance query gov-state --testnet-magic 4 | \
-jq -r '.gov.curGovSnapshots.psGovActionStates["df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79#0"]'
+cardano-cli conway query gov-state --testnet-magic 4 | \
+jq -r '.proposals.psGovActionStates["df58f714c0765f3489afb6909384a16c31d600695be7e86ff9c59cf2e8a48c79#0"]'
 ```
 ```
 {


### PR DESCRIPTION
- Fixed typo in `transaction build` command.
- Separated commands from their outputs (for easier copy/paste).
- Used `govActDeposit` Variable for the first `update-committee` governance action to demonstrate that it can be used this way. (As it is right now, Line 82 is giving no output on terminal as a variable).
- Fixed a typo in `query gov-state` command.
- Add discord meetups every thursdays.