### PR TITLE
Additional style guide edits

### DIFF
--- a/docs/get-started/get-started.mdx
+++ b/docs/get-started/get-started.mdx
@@ -13,7 +13,7 @@ SanchoNet is the testnet for rolling out groundbreaking governance features for 
 
 As SanchoNet advances in its journey of implementation and feature rollout, the community is encouraged to embrace specific roles crucial for testing and refining the governance mechanisms:
 
-1. **Testnet token holders**:
+1. **Testnet ada holders**:
 As a testnet token holder, your role is paramount. You can engage in crafting and submitting governance actions, and your insights will be invaluable to ensure that the governance system upholds the highest standards of security and efficiency.
 
 2. **Stake pool operators** (SPOs):

--- a/docs/get-started/get-started.mdx
+++ b/docs/get-started/get-started.mdx
@@ -13,8 +13,8 @@ SanchoNet is the testnet for rolling out groundbreaking governance features for 
 
 As SanchoNet advances in its journey of implementation and feature rollout, the community is encouraged to embrace specific roles crucial for testing and refining the governance mechanisms:
 
-1. **Test-ada holders**:
-As a test-ada holder, your role is paramount. You can engage in crafting and submitting governance actions, and your insights will be invaluable to ensure that the governance system upholds the highest standards of security and efficiency.
+1. **Testnet token holders**:
+As a testnet token holder, your role is paramount. You can engage in crafting and submitting governance actions, and your insights will be invaluable to ensure that the governance system upholds the highest standards of security and efficiency.
 
 2. **Stake pool operators** (SPOs):
 SPOs are the backbone of any blockchain network, and on SanchoNet, it's no different. As an SPO, you can take charge and run the testnet network with diligence and integrity and of course, you can influence Barataria's future voting on relevant actions. Your feedback will be invaluable.
@@ -26,11 +26,11 @@ DReps are the voice of the broader community. As a representative, your role inv
 
 SanchoNet is all about developing and testing the technical components and processes required to action governance for Cardano within CIP-1694. It informs and engages the Cardano community on Voltaire on-chain governance activities currently underway.
 
-To fully utilize the on-chain components as they are designed for ultimate use on mainnet, a significant program of off-chain elements (e.g. committees, informational tools, etc.) will also need to be delivered, subject to a separate complimentary roadmap and timeline.
+To fully utilize the on-chain components as they are designed for ultimate use on mainnet, a significant program of off-chain elements (eg committees, informational tools, etc) will also need to be delivered, subject to a separate complimentary roadmap and timeline.
 
-As such, SanchoNet will follow an independent development trajectory scoped from a technical, rather than final, governance perspective. SanchoNet will encapsulate the various actions and use cases that SPOs, DReps and other users will undertake within typical usage situations as the wider governance capabilities are rolled out.
+As such, SanchoNet will follow an independent development trajectory scoped from a technical, rather than final, governance perspective. SanchoNet will encapsulate the various actions and use cases that SPOs, DReps, and other users will undertake within typical usage situations as the wider governance capabilities are rolled out.
 
-Therefore not all SanchoNet functionality will operate initially as finally intended (for example, within constitutional actions), and will be subject to change and iteration during the course of development.
+Therefore, not all SanchoNet functionality will operate initially as intended (for example, within constitutional actions), and will be subject to change and iteration during the course of development.
 
 SanchoNet is more than just a testnet, it is a playground of opportunities. Within this space, the community can collaboratively create a governance system that is robust,
 decentralized, and truly community-driven. Your involvement, dedication, and passion will be the driving force behind SanchoNet's success.

--- a/docs/get-started/get-started.mdx
+++ b/docs/get-started/get-started.mdx
@@ -14,7 +14,7 @@ SanchoNet is the testnet for rolling out groundbreaking governance features for 
 As SanchoNet advances in its journey of implementation and feature rollout, the community is encouraged to embrace specific roles crucial for testing and refining the governance mechanisms:
 
 1. **Testnet ada holders**:
-As a testnet token holder, your role is paramount. You can engage in crafting and submitting governance actions, and your insights will be invaluable to ensure that the governance system upholds the highest standards of security and efficiency.
+As a testnet ada holder, your role is paramount. You can engage in crafting and submitting governance actions, and your insights will be invaluable to ensure that the governance system upholds the highest standards of security and efficiency.
 
 2. **Stake pool operators** (SPOs):
 SPOs are the backbone of any blockchain network, and on SanchoNet, it's no different. As an SPO, you can take charge and run the testnet network with diligence and integrity and of course, you can influence Barataria's future voting on relevant actions. Your feedback will be invaluable.

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -16,7 +16,7 @@ sidebar_position: 1
 * [Draft Conway design CDDL](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/conway/impl/cddl-files/conway.cddl)
 * [Conway ledger backlog](https://github.com/input-output-hk/cardano-ledger/issues?q=is%3Aissue+is%3Aopen+label%3Aconway)
 
-### DB-Sync
+### DB Sync
 
 * [Sancho-2-2-0 build](https://github.com/input-output-hk/cardano-db-sync/releases/tag/sancho-2-2-0)
 * [Sancho-2-2-0 ChangeLog](https://gist.github.com/kderme/33174fdb2cba360ff6b5da72bd961bd8#220)

--- a/docs/tutorials/delegate-to-drep.mdx
+++ b/docs/tutorials/delegate-to-drep.mdx
@@ -34,7 +34,7 @@ cardano-cli conway stake-address vote-delegation-certificate \
 --out-file vote-deleg.cert
 ```
 
-* Delegating to the `--always-no-confidence` default DRep 
+* Delegating to the `--always-no-confidence` default DRep: 
 
 ```
 cardano-cli conway stake-address vote-delegation-certificate \

--- a/docs/tutorials/keys-and-address.mdx
+++ b/docs/tutorials/keys-and-address.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 slug: /tutorials/address
 ---
 
-First, generate a payment key pair and a stake key pair. Then, use the payment verification key and the stake verification key to build an address which can be used to receive funds from the faucet.
+First, generate a payment key pair and a stake key pair. Then, use the payment verification key and the stake verification key to build an address that can be used to receive funds from the faucet.
 
 The payment keys control the funds, while the stake keys control the participation in the protocol: delegating stake to a pool and delegating votes to a delegate representative.
 
@@ -45,4 +45,4 @@ cardano-cli conway address build \
 
 ### Get funds from the faucet
 
-4. Use your address on the [faucet](faucet.mdx) to get SanchoNet tAda
+4. Use your address on the [faucet](faucet.mdx) to get SanchoNet testnet tokens.

--- a/docs/tutorials/register-spo.mdx
+++ b/docs/tutorials/register-spo.mdx
@@ -9,11 +9,11 @@ slug: /tutorials/stake-pool-registration
 
 ### Prerequisites
 
-Before you start, ensure that you are familiar with:
+Before you start, ensure that you have:
 
-1. Running a node: [see the tutorial](start-a-node.mdx)
+1. A running node: [see the tutorial](start-a-node.mdx)
 2. Created keys and addresses: [see the tutorial](keys-and-address.mdx)
-3. Requested funds from the [faucet:](faucet.mdx)
+3. Requested funds from the [faucet](faucet.mdx)
 
 ### Set up a relay node
 

--- a/docs/tutorials/start-a-node.mdx
+++ b/docs/tutorials/start-a-node.mdx
@@ -7,7 +7,7 @@ slug: /tutorials/start-node
 
 ### Download or build cardano-node and cardano-cli binaries:
 
-* The latest version for SanchoNet is **8.3.0-pre**. [See releases](https://github.com/input-output-hk/cardano-node/releases)
+* The latest version for SanchoNet is **8.3.0-pre**. [See releases](https://github.com/input-output-hk/cardano-node/releases).
 
 ### Get configuration files
 
@@ -32,4 +32,4 @@ cardano-node run --topology topology.json \
 
 ### Need help?
 
-For a step-by-step tutorial on how to build and run a node please visit  [CARDANO-NODE course | Building and running the node](https://cardano-course.gitbook.io/cardano-course/handbook/module-1-build-and-run-the-node/building-the-node)
+For a step-by-step tutorial on how to build and run a node please visit  [Cardano node course | Building and running the node](https://cardano-course.gitbook.io/cardano-course/handbook/module-1-build-and-run-the-node/building-the-node).


### PR DESCRIPTION
IOG style guide discourages the use of the phrase 'test ada'. The suggestion is to replace such mentions (and I found just one example) with 'testnet token'.  This PR also suggests replacing tAda with a testnet token. If we're talking about the ticker name, should it be 'tADA' then? This PR also suggests minor additional tweaks.