### PR TITLE
Update file-naming-convention.mdx (DRepID)

### DIFF
--- a/docs/tutorials/file-naming-convention.mdx
+++ b/docs/tutorials/file-naming-convention.mdx
@@ -97,11 +97,11 @@ The keys derived from hardware wallets will have the keyword 'Hardware' in the d
 
 #### Identification file (ID)
 
-`drep.id / *.drep.id` for the DRep ID in bech format `drep_id1...`
+`drep.id / *.drep.id` for the DRep ID in bech format `drep1...`
 
 Example content:
 
-`drep_id12dggdndq3hhjzszukw5k5sulsesjux780s39h087s0p9vk6ylra`
+`drep12dggdndq3hhjzszukw5k5sulsesjux780s39h087s0p9vk6ylra`
 
 #### Registration certificate
 


### PR DESCRIPTION
changed the examples from `drep_id1...` to `drep1...` because the `_id` was removed