### PR TITLE
Add Plutarch to "tools by the community" list

### DIFF
--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -74,6 +74,7 @@ Disclaimer: These tools and guides are created by the community and are not supp
 * [Cexplorer.io SanchoNet](https://sancho.cexplorer.io/): The biggest and oldest Cardano explorer, supporting the SanchoNet testing network.
 * [cardano-wallet Conway release](https://github.com/cardano-foundation/cardano-wallet/releases/tag/v2024-03-01): Cardano wallet is command line based software wallet.
 * [drep.tools](https://drep.tools/): A very early version of a site to help DReps by.
+* [Plutarch](https://github.com/Plutonomicon/plutarch-plutus): A Haskell eDSL designed for writing fast and fine-tunable on-chain scripts. Currently supports PlutusLedger V1 and V2, with [V3 on its way](https://github.com/Plutonomicon/plutarch-plutus/issues/655). 
 
 ### Guides from the community:
 


### PR DESCRIPTION
Adds Plutarch to the community tools list. Plutarch is a Haskell eDSL for writing on-chain scripts that aims to be fast and fine-tunable than its alternatives. Currently V1 and V2 PlutusLedger is supported, but V3 is in development under Intersect grant. 