### PR TITLE
imp: add sanchonet faucet return address

### DIFF
--- a/docs/faucet.mdx
+++ b/docs/faucet.mdx
@@ -15,3 +15,8 @@ import Faucet from "../src/components/Faucet";
 4. Click 'Submit'.
 
 <Faucet />
+
+<br />
+When you have finished using your test tokens,<br />
+please return them to the faucet at the following address:
+addr_test1vz0ua2vyk7r4vufmpqh5v44awg8xff26hxlwyrt3uc67maqtql3kl


### PR DESCRIPTION
* Adds a sanchonet faucet return address to the faucet page.
* Local dev rendering appears as follows:
![image](https://github.com/input-output-hk/sanchonet/assets/39752197/d272f219-47c7-4ef2-b4b7-23c1b914cc5d)
