### PR TITLE
Update participation requirements.

### DIFF
--- a/docs/drep-pioneer-program/participation-reqs.mdx
+++ b/docs/drep-pioneer-program/participation-reqs.mdx
@@ -15,15 +15,14 @@ To successfully complete this training, participants should:
 
 * Understand how the Cardano blockchain works.
 * Be familiar with Cardano wallets and how they work.
-* Be able to use the `cardano-cli` to run simple scripts.
 
 ### Participants Preparation
 
-To participate in the training, participants should have the following software:
+To participate in the training, participants should have the following:
 
-* A desktop operating system capable of running nix (Linux, Apple macOS, or Microsoft Windows with the Windows Subsystem Linux (WSL) enabled).
 * Any of the following web browsers: Google Chrome, Brave, or Microsoft Edge.
-* The Lace wallet with an active address. Instructions on how to set up a Lace wallet can be found [here](https://www.lace.io/faq).
+* A CIP-95 capable wallet with an active address. The list of compatible wallets can be found [here](https://docs.sanchogov.tools/how-to-use-the-govtool/getting-started/get-a-compatible-wallet).
+* A reliable internet connection, if you are attending the DRep training online.
 
 ## Instructor Requirements
 


### PR DESCRIPTION
1. Remove requirement for cardano-cli for participants as they can use the GovTool in sancho net. This is also in line with the training program content created for the DRep Training Programme. 

2. The participants can use any CIP-95 comaptible wallet. Need not be Lace wallet itself. 

3. Added a note for reliable internet connection for attending the DRep training in online mode. 