### PR TITLE
add new link for Constitution checker tool

### DIFF
--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -93,7 +93,7 @@ Disclaimer: These tools and guides are created by the community and are not supp
 * [drep.tools](https://drep.tools/): A very early version of a site to help DReps.
 * [Plutarch](https://github.com/Plutonomicon/plutarch-plutus): A Haskell eDSL designed for writing fast and fine-tunable on-chain scripts. Currently supports PlutusLedger V1 and V2, with [V3 on its way](https://github.com/Plutonomicon/plutarch-plutus/issues/655).
 * [carp 3.2.0](https://github.com/dcSpark/carp/releases/tag/3.2.0) This project is designed to sync data from the Cardano blockchain and store it into a Postgres database.
-* [Constitution Checker](http://ec2-16-171-11-232.eu-north-1.compute.amazonaws.com:8080/) Constitution checker is a web-based tool that checks the constitutionality of a Parameter Update Proposal. It implements checks for the guardrails from the [Constitution](https://raw.githubusercontent.com/IntersectMBO/interim-constitution/main/cardano-constitution-0.txt).
+* [Parameter Proposal Guardrails Checker](http://ec2-16-171-11-232.eu-north-1.compute.amazonaws.com:8080/) The Parameter Proposal Guardrails Checker is a web-based tool that checks the constitutionality of a Parameter Update Proposal. It implements checks for the guardrails from the [Constitution](https://raw.githubusercontent.com/IntersectMBO/interim-constitution/main/cardano-constitution-0.txt).
 
 ### Guides from the community:
 

--- a/docs/tools-resources/resources.mdx
+++ b/docs/tools-resources/resources.mdx
@@ -93,6 +93,7 @@ Disclaimer: These tools and guides are created by the community and are not supp
 * [drep.tools](https://drep.tools/): A very early version of a site to help DReps.
 * [Plutarch](https://github.com/Plutonomicon/plutarch-plutus): A Haskell eDSL designed for writing fast and fine-tunable on-chain scripts. Currently supports PlutusLedger V1 and V2, with [V3 on its way](https://github.com/Plutonomicon/plutarch-plutus/issues/655).
 * [carp 3.2.0](https://github.com/dcSpark/carp/releases/tag/3.2.0) This project is designed to sync data from the Cardano blockchain and store it into a Postgres database.
+* [Constitution Checker](http://ec2-16-171-11-232.eu-north-1.compute.amazonaws.com:8080/) Constitution checker is a web-based tool that checks the constitutionality of a Parameter Update Proposal. It implements checks for the guardrails from the [Constitution](https://raw.githubusercontent.com/IntersectMBO/interim-constitution/main/cardano-constitution-0.txt).
 
 ### Guides from the community:
 


### PR DESCRIPTION
[This](http://ec2-16-171-11-232.eu-north-1.compute.amazonaws.com:8080/) is a tool my team developed to be added to the GovTools. I would like to have this listed on the docs so people can find it easier. 